### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Manual escape hatch: republish the version currently on main, for when a
+  # release was tagged but its publish step failed.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -23,7 +26,9 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: >-
+      needs.release-please.outputs.release_created == 'true' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,6 +46,7 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
+      # Authenticates via OIDC trusted publishing (no token); the id-token
+      # permission above is what npm exchanges for short-lived credentials,
+      # and it is also what signs the provenance attestation.
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
Fixes the failed v2.0.0 publish ([run 32069993969](https://github.com/oleksii-donoha/oleksii-donoha/actions/runs/32069993969)).

## What broke

`npm publish` failed with `E404 Not Found - PUT .../@oleksii-donoha%2frds-port-forward`. The package obviously exists, and npm reports auth failures on scoped packages as 404 rather than 403 — the `NPM_ACCESS_TOKEN` secret dates from 2025-05-15 and npm no longer accepts it (the run log also carries npm's notice about restricting tokens that bypass 2FA).

Everything else in that run succeeded: `npm ci`, tests, build, the 2.0.0 tarball, and the signed provenance statement. The GitHub release and `v2.0.0` tag exist — only the registry upload failed.

## What this changes

- **Removes `NODE_AUTH_TOKEN`.** Publishing now authenticates via OIDC trusted publishing: npm exchanges the workflow's `id-token` for short-lived credentials. Nothing left to expire or rotate, and provenance keeps working (it uses the same `id-token: write` permission, already present).
- **Adds `workflow_dispatch`.** The publish job is now reachable manually, so a release that was tagged but failed to publish can be pushed to the registry without cutting a new version — which is exactly the situation v2.0.0 is in.

## Required before this can publish

Trusted publishing must be configured **on npmjs.com** (I can't do this — it's your account):

**npmjs.com → the package → Settings → Trusted Publisher → GitHub Actions**, then:
- Organization/user: `oleksii-donoha`
- Repository: `oleksii-donoha`
- Workflow filename: `release.yml`
- Environment: leave blank

Requirements are already met on this side: `id-token: write` is set, and Node 24 ships npm 11.17 (trusted publishing needs npm ≥ 11.5.1).

Once that's saved and this PR is merged, running the Release workflow via **Actions → Release → Run workflow** publishes 2.0.0. The `NPM_ACCESS_TOKEN` secret can then be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)